### PR TITLE
Avoid newlines in setup.py description

### DIFF
--- a/qiskit-textbook-src/setup.py
+++ b/qiskit-textbook-src/setup.py
@@ -1,12 +1,13 @@
-from setuptools import setup, find_packages
+description = ('A collection of widgets, tools and games for using along '
+               'the Qiskit Textbook. See the textbook and a list of '
+               'contributors at qiskit.org/textbook')
 
 setup(
   name='qiskit-textbook',
   version='0.1.0',
   author='Qiskit Team',
   author_email='hello@qiskit.org',
-  description='''A collection of widgets, tools and games for using along
-  the Qiskit Textbook. See the textbook and a list of contributors at qiskit.org/textbook''',
+  description=description,
   packages=find_packages(),
   install_requires=[
     'qiskit',


### PR DESCRIPTION

# Changes made
Remove newline in setup.py `description` string.

# Justification

The newlines don't work with setuptools 59+ which
causes pip install to fail.

Closes #1327
